### PR TITLE
[SIM_FLUTTER-55] [BE] Create filter by category/type of transaction API

### DIFF
--- a/backend/app/Http/Controllers/TransactionController.php
+++ b/backend/app/Http/Controllers/TransactionController.php
@@ -63,10 +63,11 @@ class TransactionController extends Controller
 
     public function index(Request $request, Account $account = null)
     {
-        //Get transactions by all or through accounts
+        // Get transactions by all or through accounts
+        // For shallow nesting see https://laravel.com/docs/8.x/controllers#shallow-nesting
         $transactions = $account ? $account->accountTransactions : Transaction::all();
 
-        //Filter transactions by transaction type
+        // Filter transactions by transaction type
         if (in_array($request->type, config('enums.transaction_type'))) {
             $transactions = $transactions->where('transaction_type', $request->type);
         }

--- a/backend/app/Http/Controllers/TransactionController.php
+++ b/backend/app/Http/Controllers/TransactionController.php
@@ -7,6 +7,7 @@ use App\Http\Resources\TransactionResource;
 use App\Models\Account;
 use App\Models\Transaction;
 use Exception;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class TransactionController extends Controller
@@ -60,17 +61,17 @@ class TransactionController extends Controller
         return $sendRow;
     }
 
-    public function index(Account $account = null)
+    public function index(Request $request, Account $account = null)
     {
-        // For /accounts/{account_id}/transactions
-        if ($account) {
-            // For shallow nesting
-            // See https://laravel.com/docs/8.x/controllers#shallow-nesting
-            return TransactionResource::collection($account->accountTransactions);
+        //Get transactions by all or through accounts
+        $transactions = $account ? $account->accountTransactions : Transaction::all();
+
+        //Filter transactions by transaction type
+        if (in_array($request->type, config('enums.transaction_type'))) {
+            $transactions = $transactions->where('transaction_type', $request->type);
         }
 
-        // For /transactions
-        return TransactionResource::collection(Transaction::all());
+        return TransactionResource::collection($transactions);
     }
 
     public function show(Transaction $transaction)


### PR DESCRIPTION
### Issue links
- [Backlog](https://framgiaph.backlog.com/view/SIM_FLUTTER-55)
- [Slack](https://sun-philippine.slack.com/archives/C059L7XAXFB/p1687773325601959)

### Definition of done
- [x] Add filter by transaction type in get transactions API
- [x] If type parameter/query has no value or value is not found in the enum list then it will disregard the filter by transaction type

### Notes
Routes are:
- [Postman](https://sph-flutter-simu.postman.co/workspace/SPH_FLUTTER~166b50f1-a8e9-4146-bf86-c471bcffa801/request/28082984-12fa9aac-3e55-498a-b0bc-c551826a6051) `api/transactions` to get all the transactions
- [Postman](https://sph-flutter-simu.postman.co/workspace/SPH_FLUTTER~166b50f1-a8e9-4146-bf86-c471bcffa801/request/28082984-ae53fa7d-aff9-48c7-ad3f-4d1906bc23d4) `api/accounts/{account_id}/transactions` to get all the transactions through accounts

Query the filter in postman using 2 ways below either way it will automatically add both ways in postman.
1. add `?type=value` in the postman request link/route and replace the `value` with correct `transaction_type` value
![image](https://github.com/framgia/sph-flutter/assets/114911074/4cbea323-ddc6-465c-983b-c4eb766b850c)

2. Enable/Add params with the `key` of `type` and the correct `transaction_type` value
![image](https://github.com/framgia/sph-flutter/assets/114911074/72ebf394-3bd8-4119-a5a9-e84075185162)

### Recordings

https://github.com/framgia/sph-flutter/assets/114911074/7a8604a5-5661-476c-ac36-8c8bd3fb5e50

