### PR TITLE
[SIM_FLUTTER-58] [BE] Create filter transaction by date API

### DIFF
--- a/backend/app/Http/Controllers/TransactionController.php
+++ b/backend/app/Http/Controllers/TransactionController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\TransactionPostRequest;
 use App\Http\Resources\TransactionResource;
 use App\Models\Account;
 use App\Models\Transaction;
+use Carbon\Carbon;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -70,6 +71,11 @@ class TransactionController extends Controller
         // Filter transactions by transaction type
         if (in_array($request->type, config('enums.transaction_type'))) {
             $transactions = $transactions->where('transaction_type', $request->type);
+        }
+
+        // Filter transactions by date
+        if ($request->from && $request->to) {
+            $transactions = $transactions->whereBetween('created_at', [$request->from, Carbon::make($request->to)->addDays(1)]);
         }
 
         return TransactionResource::collection($transactions);

--- a/backend/app/Http/Controllers/TransactionController.php
+++ b/backend/app/Http/Controllers/TransactionController.php
@@ -74,7 +74,7 @@ class TransactionController extends Controller
         }
 
         // Filter transactions by date
-        if ($request->from && $request->to) {
+        if (strtotime($request->from) && strtotime($request->to)) {
             $transactions = $transactions->whereBetween('created_at', [$request->from, Carbon::make($request->to)->addDays(1)]);
         }
 

--- a/backend/app/Http/Controllers/TransactionController.php
+++ b/backend/app/Http/Controllers/TransactionController.php
@@ -2,13 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\FilterTransactionRequest;
 use App\Http\Requests\TransactionPostRequest;
 use App\Http\Resources\TransactionResource;
 use App\Models\Account;
 use App\Models\Transaction;
 use Carbon\Carbon;
 use Exception;
-use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
 class TransactionController extends Controller
@@ -62,20 +63,23 @@ class TransactionController extends Controller
         return $sendRow;
     }
 
-    public function index(Request $request, Account $account = null)
+    public function index(FilterTransactionRequest $request, Account $account = null)
     {
+        $filters = $request->validated();
+
         // Get transactions by all or through accounts
         // For shallow nesting see https://laravel.com/docs/8.x/controllers#shallow-nesting
         $transactions = $account ? $account->accountTransactions : Transaction::all();
 
         // Filter transactions by transaction type
+        // TODO: add validation filter by transaction type
         if (in_array($request->type, config('enums.transaction_type'))) {
             $transactions = $transactions->where('transaction_type', $request->type);
         }
 
         // Filter transactions by date
-        if (strtotime($request->from) && strtotime($request->to)) {
-            $transactions = $transactions->whereBetween('created_at', [$request->from, Carbon::make($request->to)->addDays(1)]);
+        if (Arr::has($filters, ['from', 'to'])) {
+            $transactions = $transactions->whereBetween('created_at', [$filters['from'], Carbon::make($filters['to'])->addDays(1)]);
         }
 
         return TransactionResource::collection($transactions);

--- a/backend/app/Http/Requests/FilterTransactionRequest.php
+++ b/backend/app/Http/Requests/FilterTransactionRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FilterTransactionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            // TODO: Add validation rules for filter by type
+            'from' => ['date', 'before_or_equal:to', 'required_with:to'],
+            'to' => ['date'],
+        ];
+    }
+}


### PR DESCRIPTION
### Issue links
- [Backlog](https://framgiaph.backlog.com/view/SIM_FLUTTER-58)
- [Slack](https://sun-philippine.slack.com/archives/C059L7XAXFB/p1687848194902879)

### Definition of done
- [x] Add filter by date in get transactions API
- [x] If one of the `to` or `from` parameter/query has no value or both has no value then it will disregard the filter by date
- [x] Will work together with filter by transaction type and vice versa 

### Notes
Routes are:
- [Postman](https://sph-flutter-simu.postman.co/workspace/SPH_FLUTTER~166b50f1-a8e9-4146-bf86-c471bcffa801/request/28082984-12fa9aac-3e55-498a-b0bc-c551826a6051) `api/transactions` to get all the transactions
- [Postman](https://sph-flutter-simu.postman.co/workspace/SPH_FLUTTER~166b50f1-a8e9-4146-bf86-c471bcffa801/request/28082984-ae53fa7d-aff9-48c7-ad3f-4d1906bc23d4) `api/accounts/{account_id}/transactions` to get all the transactions through accounts

Query the filter in postman using 2 ways below either way it will automatically add both ways in postman.
1. add `?to=value&from=value` in the postman request link/route and replace the `value` with correct `to` and `from` value
![image](https://github.com/framgia/sph-flutter/assets/114911074/23dc3fe4-2fc8-4db5-8e4c-4d32225574c1)

2. Enable/Add params with the `key` of `to` and `from` then the correct date value to each of the parameters
![image](https://github.com/framgia/sph-flutter/assets/114911074/ae10e789-ac99-4e46-a2eb-1740e45ed309)

### Recordings

https://github.com/framgia/sph-flutter/assets/114911074/81e9fd8e-29a9-4f8c-9d13-808e192cb2c5

