### PR TITLE
Practice/reset password integration

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -91,7 +91,7 @@ class AuthController extends Controller
             ]);
         } else {
             throw ValidationException::withMessages([
-                'message' => 'Unable to send the reset link again, please double check your email',
+                'email' => ['Unable to send the reset link again, please double check your email'],
             ]);
         }
     }
@@ -105,7 +105,7 @@ class AuthController extends Controller
 
         if (! $user || Hash::check($validated['password'], $user->password)) {
             throw ValidationException::withMessages([
-                'message' => 'password should not be an old password',
+                'password' => 'password should not be an old password',
             ]);
         }
 
@@ -135,7 +135,7 @@ class AuthController extends Controller
             ]);
         } else {
             throw ValidationException::withMessages([
-                'message' => 'Your provided credentials could not be verified.',
+                'password' => 'Your provided token could not be verified.',
             ]);
         }
     }

--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -17,6 +17,7 @@ use App\Models\User;
 use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -40,7 +41,7 @@ class AuthController extends Controller
     {
         $credentials = $request->validated();
 
-        if (! Auth::attempt($credentials)) {
+        if (!Auth::attempt($credentials)) {
             throw ValidationException::withMessages([
                 'email' => 'Your provided credentials could not be verified.',
             ]);
@@ -85,6 +86,8 @@ class AuthController extends Controller
             ['email' => $validated['email']]
         );
 
+        Log::debug("Send Reset Link Status: [ $status ]");
+
         if ($status === Password::RESET_LINK_SENT) {
             return ForgotPasswordResource::make([
                 'message' => 'The link was sent, please check your email',
@@ -103,7 +106,7 @@ class AuthController extends Controller
 
         $user = User::where('email', $validated['email'])->first();
 
-        if (! $user || Hash::check($validated['password'], $user->password)) {
+        if (!$user || Hash::check($validated['password'], $user->password)) {
             throw ValidationException::withMessages([
                 'password' => 'password should not be an old password',
             ]);

--- a/frontend/lib/src/features/password_reset/components/reset_password_page.dart
+++ b/frontend/lib/src/features/password_reset/components/reset_password_page.dart
@@ -1,0 +1,183 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:frontend/src/controllers/login_controller.dart';
+import 'package:frontend/src/helper/dio.dart';
+import 'package:get/get.dart';
+
+import 'package:frontend/src/features/login/login_page.dart';
+import 'package:frontend/src/components/auth/auth_header.dart';
+import 'package:frontend/src/components/input/input_field.dart';
+import 'package:frontend/src/components/button.dart';
+
+/*
+  Page for the Password Reset
+  User inputs email
+*/
+class ResetPasswordPage extends StatelessWidget {
+  const ResetPasswordPage({super.key, required this.emailValue});
+
+  final String emailValue;
+  @override
+  Widget build(BuildContext context) {
+    //LoginController is being used here
+    //so that the button will disable and to avoid duplicated code
+    final LoginController loginController = Get.put(LoginController());
+    final formKey = GlobalKey<FormBuilderState>();
+    final networkConfig = NetworkConfig();
+
+    void onSubmit() async {
+      // disable the button to prevent multiple requests being sent
+      loginController.setLoginButtonEnabled = false;
+
+      final client = networkConfig.client;
+
+      final email = emailValue;
+      final password = formKey.currentState!.fields['password']!.value;
+      final passwordConfirmation =
+          formKey.currentState!.fields['password_confirmation']!.value;
+      final token = formKey.currentState!.fields['token']!.value;
+
+      final resetPasswordResponse = await client.post(
+        resetPasswordtUrl,
+        data: {
+          'email': email,
+          'password': password,
+          'password_confirmation': passwordConfirmation,
+          'token': token,
+        },
+      );
+
+      if (resetPasswordResponse.statusCode == HttpStatus.ok) {
+        Get.to(() => const LoginPage());
+      } else if (resetPasswordResponse.statusCode == HttpStatus.badRequest) {
+        // the error response is in Response<dynamic>, toString + jsonDecode to easily access data
+        final error = jsonDecode(resetPasswordResponse.data.toString());
+        // just use the first validation error (if many)
+        final message = error['error']['message']['password'][0];
+
+        message == 'password should not be an old password'
+            ? formKey.currentState?.fields['password']?.invalidate(message)
+            : message == 'The password confirmation does not match.'
+                ? formKey.currentState?.fields['password_confirmation']
+                    ?.invalidate(message)
+                : formKey.currentState?.fields['token']?.invalidate(message);
+      }
+    }
+
+    return SafeArea(
+      child: Scaffold(
+        body: AuthHeader(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(25, 0, 25, 150),
+            child: GetX<LoginController>(
+              builder: (_) => FormBuilder(
+                key: formKey,
+                autovalidateMode: AutovalidateMode.disabled,
+                onChanged: () {
+                  formKey.currentState!.save();
+
+                  // when password is invalidated on the onSubmit,
+                  // revalidate the password field when typing again
+                  formKey.currentState?.fields['password']
+                      ?.validate(focusOnInvalid: false);
+
+                  // set button enabled state
+                  loginController.setLoginButtonEnabled =
+                      formKey.currentState!.fields['password']!.isValid &&
+                          formKey.currentState!.fields['password_confirmation']!
+                              .isValid &&
+                          formKey.currentState!.fields['token']!.isValid;
+                },
+                child: Column(
+                  children: [
+                    Column(
+                      children: [
+                        Container(
+                          margin: const EdgeInsets.only(bottom: 40),
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'Create New Password',
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                        ),
+                        Container(
+                          margin: const EdgeInsets.only(bottom: 14),
+                          child: Column(
+                            children: [
+                              InputField(
+                                name: 'password',
+                                label: 'Password',
+                                inputType: TextInputType.visiblePassword,
+                                obscureText: true,
+                                validator: FormBuilderValidators.required(),
+                              ),
+                              const SizedBox(
+                                height: 36,
+                              ),
+                              InputField(
+                                name: 'password_confirmation',
+                                label: 'Confirm Password',
+                                inputType: TextInputType.visiblePassword,
+                                obscureText: true,
+                                validator: FormBuilderValidators.required(),
+                              ),
+                              const SizedBox(
+                                height: 36,
+                              ),
+                              InputField(
+                                name: 'token',
+                                label: 'Token',
+                                inputType: TextInputType.text,
+                                validator: FormBuilderValidators.required(),
+                              ),
+                            ],
+                          ),
+                        ),
+                        Container(
+                          alignment: Alignment.centerRight,
+                          margin: const EdgeInsets.only(bottom: 60),
+                          child: TextButton(
+                            onPressed: () {
+                              Get.to(() => const LoginPage());
+                            },
+                            child: Text(
+                              'Back to Login',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelSmall!
+                                  .copyWith(
+                                    color:
+                                        const Color.fromARGB(255, 0, 163, 255),
+                                  ),
+                            ),
+                          ),
+                        ),
+                        Button(
+                          onPressed: loginController.loginButtonEnabled
+                              ? onSubmit
+                              : null,
+                          buttonColor: loginController.loginButtonEnabled
+                              ? const Color(0xFF00CCFF)
+                              : Colors.grey,
+                          text: 'Send',
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 16,
+                            horizontal: 99,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/src/features/password_reset/password_reset_page.dart
+++ b/frontend/lib/src/features/password_reset/password_reset_page.dart
@@ -38,13 +38,21 @@ class PasswordResetPage extends StatelessWidget {
       final email = formKey.currentState!.fields['email']!.value;
 
       final forgotPasswordResponse = await client.post(
-        forgotPasswordtUrl,
+        forgotPasswordUrl,
         data: {
           'email': email,
         },
       );
 
-      if (forgotPasswordResponse.statusCode == HttpStatus.badRequest) {
+      if (forgotPasswordResponse.statusCode != HttpStatus.badRequest) {
+        showAlertDialog(
+          title: 'SUCCESS',
+          content: 'The link was sent, please check your email',
+          onClick: () {
+            Get.to(ResetPasswordPage(emailValue: email));
+          },
+        );
+      } else {
         // the error response is in Response<dynamic>, toString + jsonDecode to easily access data
         final error = jsonDecode(forgotPasswordResponse.data.toString());
         // just use the first validation error (if many)
@@ -58,14 +66,6 @@ class PasswordResetPage extends StatelessWidget {
                   Get.to(ResetPasswordPage(emailValue: email));
                 },
               );
-      } else {
-        showAlertDialog(
-          title: 'SUCCESS',
-          content: 'The link was sent, please check your email',
-          onClick: () {
-            Get.to(ResetPasswordPage(emailValue: email));
-          },
-        );
       }
     }
 

--- a/frontend/lib/src/features/password_reset/password_reset_page.dart
+++ b/frontend/lib/src/features/password_reset/password_reset_page.dart
@@ -1,6 +1,13 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:frontend/src/controllers/login_controller.dart';
+import 'package:frontend/src/features/password_reset/components/reset_password_page.dart';
+import 'package:frontend/src/helper/dialog/show_alert_dialog.dart';
+import 'package:frontend/src/helper/dio.dart';
 import 'package:get/get.dart';
 
 import 'package:frontend/src/features/login/login_page.dart';
@@ -16,69 +23,137 @@ class PasswordResetPage extends StatelessWidget {
   const PasswordResetPage({super.key});
   @override
   Widget build(BuildContext context) {
+    //LoginController is being used here
+    //so that the button will disable and to avoid duplicated code
+    final LoginController loginController = Get.put(LoginController());
     final formKey = GlobalKey<FormBuilderState>();
+    final networkConfig = NetworkConfig();
+
+    void onSubmit() async {
+      // disable the button to prevent multiple requests being sent
+      loginController.setLoginButtonEnabled = false;
+
+      final client = networkConfig.client;
+
+      final email = formKey.currentState!.fields['email']!.value;
+
+      final forgotPasswordResponse = await client.post(
+        forgotPasswordtUrl,
+        data: {
+          'email': email,
+        },
+      );
+
+      if (forgotPasswordResponse.statusCode == HttpStatus.badRequest) {
+        // the error response is in Response<dynamic>, toString + jsonDecode to easily access data
+        final error = jsonDecode(forgotPasswordResponse.data.toString());
+        // just use the first validation error (if many)
+        final message = error['error']['message']['email'][0];
+        message == 'The selected email is invalid.'
+            ? formKey.currentState?.fields['email']?.invalidate(message)
+            : showAlertDialog(
+                title: 'ERROR',
+                content: message,
+                onClick: () {
+                  Get.to(ResetPasswordPage(emailValue: email));
+                },
+              );
+      } else {
+        showAlertDialog(
+          title: 'SUCCESS',
+          content: 'The link was sent, please check your email',
+          onClick: () {
+            Get.to(ResetPasswordPage(emailValue: email));
+          },
+        );
+      }
+    }
 
     return SafeArea(
       child: Scaffold(
         body: AuthHeader(
-          child: FormBuilder(
-            key: formKey,
-            autovalidateMode: AutovalidateMode.always,
-            onChanged: () {
-              formKey.currentState!.save();
-            },
-            child: Column(
-              children: [
-                Container(
-                  width: double.maxFinite,
-                  margin: const EdgeInsets.symmetric(horizontal: 25, vertical: 0),
-                  child: Column(
-                    children: [
-                      Container(
-                        margin: const EdgeInsets.only(bottom: 40),
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          'Forgot Password',
-                          style: Theme.of(context).textTheme.titleMedium,
-                        ),
-                      ),
-                      Container(
-                        margin: const EdgeInsets.only(bottom: 14),
-                        child: InputField(
-                          name: 'email',
-                          label: 'Enter Email',
-                          validator: FormBuilderValidators.email(),
-                        ),
-                      ),
-                      Container(
-                        alignment: Alignment.centerRight,
-                        margin: const EdgeInsets.only(bottom: 60),
-                        child: TextButton(
-                          onPressed: () {
-                            Get.to(() => const LoginPage());
-                          },
+          child: GetX<LoginController>(
+            builder: (_) => FormBuilder(
+              key: formKey,
+              autovalidateMode: AutovalidateMode.disabled,
+              onChanged: () {
+                formKey.currentState!.save();
+
+                // when email is invalidated on the onSubmit,
+                // revalidate the email field when typing again
+                formKey.currentState?.fields['email']
+                    ?.validate(focusOnInvalid: false);
+
+                // set button enabled state
+                loginController.setLoginButtonEnabled =
+                    formKey.currentState!.fields['email']!.isValid;
+              },
+              child: Column(
+                children: [
+                  Container(
+                    width: double.maxFinite,
+                    margin:
+                        const EdgeInsets.symmetric(horizontal: 25, vertical: 0),
+                    child: Column(
+                      children: [
+                        Container(
+                          margin: const EdgeInsets.only(bottom: 40),
+                          alignment: Alignment.centerLeft,
                           child: Text(
-                            'Back to Login',
-                            style: Theme.of(context).textTheme.labelSmall!.copyWith(
-                                  color: const Color.fromARGB(255, 0, 163, 255),
-                                ),
+                            'Forgot Password',
+                            style: Theme.of(context).textTheme.titleMedium,
                           ),
                         ),
-                      ),
-                      Button(
-                        text: 'Send',
-                        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 99),
-                        onPressed: () {
-                          if (formKey.currentState?.isValid ?? false) {
-                            debugPrint(formKey.currentState?.value.toString());
-                            Get.back();
-                          }
-                        },
-                      ),
-                    ],
+                        Container(
+                          margin: const EdgeInsets.only(bottom: 14),
+                          child: InputField(
+                            name: 'email',
+                            label: 'Enter Email',
+                            validator: FormBuilderValidators.compose(
+                              [
+                                FormBuilderValidators.required(),
+                                FormBuilderValidators.email(),
+                              ],
+                            ),
+                          ),
+                        ),
+                        Container(
+                          alignment: Alignment.centerRight,
+                          margin: const EdgeInsets.only(bottom: 60),
+                          child: TextButton(
+                            onPressed: () {
+                              Get.to(() => const LoginPage());
+                            },
+                            child: Text(
+                              'Back to Login',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelSmall!
+                                  .copyWith(
+                                    color:
+                                        const Color.fromARGB(255, 0, 163, 255),
+                                  ),
+                            ),
+                          ),
+                        ),
+                        Button(
+                          onPressed: loginController.loginButtonEnabled
+                              ? onSubmit
+                              : null,
+                          buttonColor: loginController.loginButtonEnabled
+                              ? const Color(0xFF00CCFF)
+                              : Colors.grey,
+                          text: 'Send',
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 16,
+                            horizontal: 99,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/frontend/lib/src/helper/dialog/show_alert_dialog.dart
+++ b/frontend/lib/src/helper/dialog/show_alert_dialog.dart
@@ -7,11 +7,15 @@ import 'package:get/get.dart';
   @param title: String value to display the title of the alert dialog
 
   @param content: String value to display the content of the alert dialog
+
+  @param onClick: VoidCallback function to execute when the user clicks "Okay"
+
 */
 
 void showAlertDialog({
   required String title,
   required String content,
+  VoidCallback? onClick,
 }) {
   Get.dialog(
     AlertDialog(
@@ -19,9 +23,7 @@ void showAlertDialog({
       content: Text(content),
       actions: [
         TextButton(
-          onPressed: () {
-            Get.back();
-          },
+          onPressed: onClick ?? () => Get.back(),
           child: const Text('Okay'),
         ),
       ],

--- a/frontend/lib/src/helper/dio.dart
+++ b/frontend/lib/src/helper/dio.dart
@@ -17,6 +17,8 @@ const loginUrl = '$apiUrl/login';
 const usersUrl = '$apiUrl/users';
 const authUrl = '$apiUrl/auth';
 const logoutUrl = '$apiUrl/logout';
+const forgotPasswordtUrl = '$apiUrl/forgot-password';
+const resetPasswordtUrl = '$apiUrl/reset-password';
 
 const storage = FlutterSecureStorage();
 
@@ -34,20 +36,23 @@ class NetworkConfig {
         receiveTimeout: const Duration(seconds: 2),
         contentType: 'application/json',
         responseType: ResponseType.json,
-        headers: (kIsWeb) ? {
-          "Accept": 'application/json',
-        } : {
-          HttpHeaders.userAgentHeader: "dio",
-          "Connection": "keep-alive",
-          "Accept": 'application/json',
-        },
+        headers: (kIsWeb)
+            ? {
+                "Accept": 'application/json',
+              }
+            : {
+                HttpHeaders.userAgentHeader: "dio",
+                "Connection": "keep-alive",
+                "Accept": 'application/json',
+              },
       )
       ..interceptors.add(
         InterceptorsWrapper(
           onRequest: (options, handler) async {
             // when getCsrftoken() is called, the function puts to storage the csrf token
             // for any and all subsequent requests, it will contain X-XSRF-TOKEN header
-            final csrfToken = await storage.read(key: StorageKeys.csrfToken.name);
+            final csrfToken =
+                await storage.read(key: StorageKeys.csrfToken.name);
             if (csrfToken != null) {
               options.headers['X-XSRF-TOKEN'] = csrfToken;
             }
@@ -55,7 +60,8 @@ class NetworkConfig {
             // pre-requisite is to login at frontend\lib\src\features\login\login_page.dart
             // for any and all subsequent requests, the login token will be added to
             // the headers of the requests
-            final loginToken = await storage.read(key: StorageKeys.loginToken.name);
+            final loginToken =
+                await storage.read(key: StorageKeys.loginToken.name);
             if (loginToken != null) {
               options.headers['Authorization'] = 'Bearer $loginToken';
             }
@@ -128,7 +134,8 @@ class NetworkConfig {
       );
 
       await _client.get(sanctumCsrfCookieUrl);
-      await storage.write(key: StorageKeys.csrfToken.name, value: csrfTokenValue);
+      await storage.write(
+          key: StorageKeys.csrfToken.name, value: csrfTokenValue);
 
       return csrfTokenValue;
     } catch (error, stacktrace) {

--- a/frontend/lib/src/helper/dio.dart
+++ b/frontend/lib/src/helper/dio.dart
@@ -17,7 +17,7 @@ const loginUrl = '$apiUrl/login';
 const usersUrl = '$apiUrl/users';
 const authUrl = '$apiUrl/auth';
 const logoutUrl = '$apiUrl/logout';
-const forgotPasswordtUrl = '$apiUrl/forgot-password';
+const forgotPasswordUrl = '$apiUrl/forgot-password';
 const resetPasswordtUrl = '$apiUrl/reset-password';
 
 const storage = FlutterSecureStorage();


### PR DESCRIPTION
pls test

- [slack](https://sun-philippine.slack.com/archives/C059L7XAXFB/p1688375519741309)

[Forgot Password Page only]
files involved 
- `frontend\lib\src\features\password_reset\password_reset_page.dart`
  - printing in debug console the status code (expected 200 and 400)
  - printing the error message
- `backend\storage\logs\laravel.log`
  - logging the reset password status in backend (expected sent and throttled and not showing)
- email

### Valid
1. enter valid email
2. laravel.log outputs `passwords.sent`
3. receive email
4. popup of success message
5. debug console shows `200`

### Throttled (sending the forgot password request multiple times)
1. enter same email as above
2. laravel.log outputs `passwords.throttled`
3. do not receive email
4. popup of error message
5. debug console shows 400 and error message (double check your mail)

### Invalid email (not exists)
1. enter invalid email
2. laravel.log doesnt output status
3. do not receive mail
4. validation message on the field, no popup
5. debug console shows 400, and error message (selected email is invalid)