### PR TITLE
[SIM_FLUTTER-34] [Integrate] Implement user can deposit cash

### DIFF
--- a/frontend/lib/src/components/input/input_field.dart
+++ b/frontend/lib/src/components/input/input_field.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
+
 import 'package:frontend/src/components/label.dart';
 
 /*
@@ -9,15 +11,15 @@ import 'package:frontend/src/components/label.dart';
   @param name, similar to html name attribute, provides the form widget the key to assign its value
   ex InputField(name: "last_name") , then printing the formKey values provides { last_name: "abc" }
 
-  @param label, add label to the Text Field, 
+  @param label, add label to the Text Field,
   ex InputField(label: "Enter Email")
 
-  @param initialValue, provide the text field its initial value 
+  @param initialValue, provide the text field its initial value
 
-  @param inputType, to add a inputType in the field like email field, text field, password field and ect., 
+  @param inputType, to add a inputType in the field like email field, text field, password field and ect.,
   ex InputField(inputType: TextInputType.emailAddress)
 
-  @param controller, By using a controller, you can perform various tasks such as: 
+  @param controller, By using a controller, you can perform various tasks such as:
   Retrieving input data, Setting initial values, Modifying input content, Clearing input
   ex final TextEditingController emailController = TextEditingController();
   InputField(inputType: controller: emailController,)
@@ -42,6 +44,7 @@ class InputField extends StatelessWidget {
     this.validator,
     this.obscureText = false,
     this.enabled = true,
+    this.inputFormatters,
   });
 
   final String name;
@@ -52,6 +55,7 @@ class InputField extends StatelessWidget {
   final String? Function(String?)? validator;
   final bool obscureText;
   final bool enabled;
+  final List<TextInputFormatter>? inputFormatters;
 
   @override
   Widget build(BuildContext context) {
@@ -78,6 +82,7 @@ class InputField extends StatelessWidget {
             controller: controller,
             obscureText: obscureText,
             keyboardType: inputType,
+            inputFormatters: inputFormatters,
             autovalidateMode: AutovalidateMode.onUserInteraction,
             enabled: enabled,
             decoration: const InputDecoration(

--- a/frontend/lib/src/components/transaction_component/transaction_component.dart
+++ b/frontend/lib/src/components/transaction_component/transaction_component.dart
@@ -9,6 +9,7 @@ import 'package:frontend/src/helper/dialog/show_alert_dialog.dart';
 import 'package:frontend/src/controllers/dashboard_controller.dart';
 import 'package:frontend/src/models/transaction.dart';
 import 'package:frontend/src/controllers/transaction_controller.dart';
+import 'package:frontend/src/controllers/account_details_controller.dart';
 
 /*
   Reusable transaction component for deposit, withdraw, and transfer cash
@@ -39,6 +40,8 @@ class TransactionComponent extends StatelessWidget {
   Widget build(BuildContext context) {
     final formKey = GlobalKey<FormBuilderState>();
     final DashboardController dashboardController = Get.find();
+    final AccountDetailsController accountDetailsController =
+        Get.put(AccountDetailsController());
     final TransactionController transactionController =
         Get.put(TransactionController());
 
@@ -59,6 +62,10 @@ class TransactionComponent extends StatelessWidget {
             'category': Category.BILLS,
             'success': 'withdrawn'
           },
+          TransactionTypes.DEPT: {
+            'category': Category.SAVINGS,
+            'success': 'deposited',
+          }
         };
 
         // If field is null, do not execute Get.back();
@@ -83,6 +90,7 @@ class TransactionComponent extends StatelessWidget {
           final success = typeTexts[type]?['success'];
 
           dashboardController.getUserAccounts();
+          accountDetailsController.getUserAccount(accountId: accountId);
           transactionController.setTransactionSubmitEnabled = false;
 
           Get.back();
@@ -104,7 +112,7 @@ class TransactionComponent extends StatelessWidget {
     return SingleChildScrollView(
       padding: const EdgeInsets.fromLTRB(25, 30, 25, 0),
       child: SizedBox(
-        height: 450,
+        height: type == TransactionTypes.TRANSFER ? 450 : 350,
         child: GetX<TransactionController>(
           builder: (_) => FormBuilder(
             key: formKey,

--- a/frontend/lib/src/components/transaction_component/transaction_component.dart
+++ b/frontend/lib/src/components/transaction_component/transaction_component.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:get/get.dart';
@@ -57,6 +58,7 @@ class TransactionComponent extends StatelessWidget {
         final descriptionValue =
             formKey.currentState?.fields['description']?.value;
         // Manually set category for now as there is no plan for this feature as of now
+        // TODO: Transfer type texts
         final Map<TransactionTypes, Map<String, dynamic>> typeTexts = {
           TransactionTypes.CREDIT: {
             'category': Category.BILLS,
@@ -121,8 +123,10 @@ class TransactionComponent extends StatelessWidget {
               formKey.currentState!.save();
 
               // Fields required for each type
+              // TODO: Transfer required fields
               final Map<TransactionTypes, List<String>> requiredFields = {
                 TransactionTypes.CREDIT: ['amount', 'description'],
+                TransactionTypes.DEPT: ['amount', 'description'],
               };
 
               // Enable submit button once requirements are met
@@ -160,13 +164,19 @@ class TransactionComponent extends StatelessWidget {
                 InputField(
                   name: 'amount',
                   label: 'Amount',
+                  inputFormatters: [
+                    FilteringTextInputFormatter.allow(
+                      RegExp(r'^\d+\.?\d{0,2}'),
+                    ),
+                  ],
                   validator: FormBuilderValidators.compose(
                     [
-                      FormBuilderValidators.integer(),
+                      FormBuilderValidators.numeric(),
                       FormBuilderValidators.required(),
                     ],
                   ),
-                  inputType: TextInputType.number,
+                  inputType:
+                      const TextInputType.numberWithOptions(decimal: true),
                 ),
                 const SizedBox(
                   height: 20,

--- a/frontend/lib/src/controllers/account_details_controller.dart
+++ b/frontend/lib/src/controllers/account_details_controller.dart
@@ -4,9 +4,13 @@ import 'package:frontend/src/models/account.dart';
 import 'package:frontend/src/services/account_service.dart';
 
 class AccountDetailsController extends GetxController {
-  final Rx<Account> _account =
-      Account(id: '', balance: 0, userId: '', accountType: 0, accountName: '')
-          .obs;
+  final Rx<Account> _account = Account(
+    id: '',
+    balance: 0.00,
+    userId: '',
+    accountType: 0,
+    accountName: '',
+  ).obs;
 
   Account get account => _account.value;
 

--- a/frontend/lib/src/models/account.dart
+++ b/frontend/lib/src/models/account.dart
@@ -13,7 +13,7 @@ class Account {
   String userId;
   int accountType;
   String accountName;
-  int balance;
+  double balance;
 
   Account({
     required this.id,
@@ -28,7 +28,7 @@ class Account {
         userId: json["user_id"],
         accountType: json["account_type"],
         accountName: json["account_name"],
-        balance: json["balance"],
+        balance: json["balance"].toDouble(),
       );
 
   Map<String, dynamic> toJson() => {


### PR DESCRIPTION
### Issue
[Backlog](https://framgiaph.backlog.com/view/SIM_FLUTTER-34)
[Slack](https://sun-philippine.slack.com/archives/C059L7XAXFB/p1689054742325319)

### Definition of done
- [x] User will be able to deposit through dashboard page
- [x] User will be able to deposit through account details page
- [x]  Display necessary messages for validation errors
- [x] Once the transaction is successful, remove the deposit form and display modal/pop-up for success message
- [x] Account balance will be updated accordingly in dashboard and account details page

### Notes
Only in deposit modal/pop-up form

### Recording

https://github.com/framgia/sph-flutter/assets/114911074/1437c261-2aa2-4bc6-9515-b72c12983eb2


