### PR TITLE
[SIM_FLUTTER-69] [BE] Create spending breakdown API

### DIFF
--- a/backend/app/Http/Controllers/AccountController.php
+++ b/backend/app/Http/Controllers/AccountController.php
@@ -45,7 +45,7 @@ class AccountController extends Controller
     }
 
     // api endpoint for retrieving aggregated data on an account's CREDIT transactions
-    // @param days (null | 0 | 7 | 30) filter for transaction date between Now and {days} Days before
+    // @param days (null | 1 | 7 | 30) filter for transaction date between Now and {days} Days before
     // spending breakdown groups the transactions by the categories and the main data to manage
     //   is total_transaction_amount and latest_transaction_date
     // diff_for_human data is also made available to easily display words like "Yesterday"

--- a/backend/app/Http/Controllers/AccountController.php
+++ b/backend/app/Http/Controllers/AccountController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\AccountPostRequest;
+use App\Http\Requests\SpendingBreakdownRequest;
 use App\Http\Resources\AccountResource;
+use App\Http\Resources\SpendingBreakdownResource;
 use App\Models\Account;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
@@ -40,5 +42,20 @@ class AccountController extends Controller
         $account = Account::create(array_merge($payload, ['user_id' => Auth::id()]));
 
         return AccountResource::make($account);
+    }
+
+    // api endpoint for retrieving aggregated data on an account's CREDIT transactions
+    // @param days (null | 0 | 7 | 30) filter for transaction date between Now and {days} Days before
+    // spending breakdown groups the transactions by the categories and the main data to manage
+    //   is total_transaction_amount and latest_transaction_date
+    // diff_for_human data is also made available to easily display words like "Yesterday"
+    //   instead of a date time data
+    public function spendingBreakdown(SpendingBreakdownRequest $request, Account $account)
+    {
+        $validated = $request->validated();
+
+        $result = Account::getSpendingBreakdown($validated, $account);
+
+        return SpendingBreakdownResource::make($result);
     }
 }

--- a/backend/app/Http/Controllers/TransactionController.php
+++ b/backend/app/Http/Controllers/TransactionController.php
@@ -140,7 +140,6 @@ class TransactionController extends Controller
             } catch (Exception $e) {
                 throw $e;
             }
-
         }, 5);
     }
 

--- a/backend/app/Http/Requests/SpendingBreakdownRequest.php
+++ b/backend/app/Http/Requests/SpendingBreakdownRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class SpendingBreakdownRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'days' => ['nullable', Rule::in(['0', '7', '30'])],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/SpendingBreakdownRequest.php
+++ b/backend/app/Http/Requests/SpendingBreakdownRequest.php
@@ -25,7 +25,7 @@ class SpendingBreakdownRequest extends FormRequest
     public function rules()
     {
         return [
-            'days' => ['nullable', Rule::in(['0', '7', '30'])],
+            'days' => ['nullable', Rule::in(['1', '7', '30'])],
         ];
     }
 }

--- a/backend/app/Http/Resources/SpendingBreakdownResource.php
+++ b/backend/app/Http/Resources/SpendingBreakdownResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Carbon\Carbon;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SpendingBreakdownResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array|\Illuminate\Contracts\Support\Arrayable|\JsonSerializable
+     */
+    public function toArray($request)
+    {
+        $data = collect(parent::toArray($request));
+
+        $data->map(function ($item) {
+            $item->diff_for_humans = Carbon::make($item->latest_transaction_date)
+                ->diffForHumans(
+                    ['options' => Carbon::JUST_NOW | Carbon::ONE_DAY_WORDS]
+                );
+
+            return $item;
+        });
+
+        return $data;
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -39,4 +39,5 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     Route::apiResource('accounts', AccountController::class)->only(['index', 'show', 'store']);
     Route::apiResource('accounts.transactions', TransactionController::class)->shallow()->only(['index', 'store']);
     Route::apiResource('transactions', TransactionController::class)->only(['index', 'show']);
+    Route::get('accounts/{account}/spending-breakdown', [AccountController::class, 'spendingBreakdown']);
 });


### PR DESCRIPTION
### Issue links
- [backlog](https://framgiaph.backlog.com/view/SIM_FLUTTER-69)
- [slack](https://sun-philippine.slack.com/archives/C059L7XAXFB/p1689242463710999)

### Definition of done
- [x] create spending breakdown api
- [x] able to input "days" for filtering

### Note
- postman [link](https://sph-flutter-simu.postman.co/workspace/SPH_FLUTTER~166b50f1-a8e9-4146-bf86-c471bcffa801/request/28082984-085e2f25-2928-4a99-bf3a-35a6103d363c?ctx=documentation)
- accounts collection -> spending breakdown
- route: /accounts/{{account_id}}/spending-breakdown
- on `Params` tab use `days` key, valid values are `0` `7` `30` and empty

### Recording
- 1

![image](https://github.com/framgia/sph-flutter/assets/95029803/85bf5ed1-98cd-4291-981e-726504f5e840)
