### PR TITLE
[SIM_FLUTTER-117][Improvement] Change Recipient's Name to Recipient's Complete Name

### DIFF
--- a/frontend/lib/src/components/transaction_component/transaction_component.dart
+++ b/frontend/lib/src/components/transaction_component/transaction_component.dart
@@ -103,13 +103,19 @@ class TransactionComponent extends StatelessWidget {
 
         if (type == TransactionTypes.TRANSFER) {
           if (recipientAccountNumber.length != 11) {
-            alertDialog(content: 'Account number must be 11 digits.');
+            alertDialog(
+              content: 'Account number must be 11 digits.',
+            );
+
+            return;
           } else if (recipientAccountNumber ==
               accountDetailsController.account.accountNumber) {
             alertDialog(
-                content: 'Transferring to same account is not acceptable.');
+              content: 'Transferring to same account is not acceptable.',
+            );
+
+            return;
           }
-          return;
         }
 
         final transaction = Transaction(

--- a/frontend/lib/src/components/transaction_component/transaction_component.dart
+++ b/frontend/lib/src/components/transaction_component/transaction_component.dart
@@ -60,7 +60,7 @@ class TransactionComponent extends StatelessWidget {
     // TODO: Transfer required fields
     final Map<TransactionTypes, List<String>> requiredFields = {
       TransactionTypes.CREDIT: ['amount', 'description'],
-      TransactionTypes.DEPT: ['amount', 'description'],
+      TransactionTypes.DEPT: ['amount'],
       TransactionTypes.TRANSFER: [
         'amount',
         'recipientAccountNumber',
@@ -101,16 +101,20 @@ class TransactionComponent extends StatelessWidget {
         final descriptionValue =
             formKey.currentState?.fields['description']?.value;
 
-        if (type == TransactionTypes.TRANSFER &&
-            recipientAccountNumber.length != 11) {
-          alertDialog(content: 'Account number must be 11 digits.');
-
+        if (type == TransactionTypes.TRANSFER) {
+          if (recipientAccountNumber.length != 11) {
+            alertDialog(content: 'Account number must be 11 digits.');
+          } else if (recipientAccountNumber ==
+              accountDetailsController.account.accountNumber) {
+            alertDialog(
+                content: 'Transferring to same account is not acceptable.');
+          }
           return;
         }
 
         final transaction = Transaction(
           amount: double.parse(amountValue),
-          description: descriptionValue,
+          description: descriptionValue ?? 'Deposit',
           transactionType: type,
           category: typeTexts[type]!['category'],
           accountName: accountNameValue ?? '',
@@ -204,7 +208,7 @@ class TransactionComponent extends StatelessWidget {
                   ),
                   InputField(
                     name: 'accountName',
-                    label: 'Recipient\'s Name',
+                    label: 'Recipient\'s Complete Name',
                     inputType: TextInputType.text,
                     validator: FormBuilderValidators.required(),
                   ),
@@ -263,15 +267,19 @@ class TransactionComponent extends StatelessWidget {
                 const SizedBox(
                   height: 20,
                 ),
-                InputField(
-                  name: 'description',
-                  label: 'Description',
-                  inputType: TextInputType.text,
-                  validator: FormBuilderValidators.required(),
-                ),
-                const SizedBox(
-                  height: 20,
-                ),
+                if (type != TransactionTypes.DEPT) ...[
+                  InputField(
+                    name: 'description',
+                    label: type == TransactionTypes.TRANSFER
+                        ? 'Purpose'
+                        : 'Description',
+                    inputType: TextInputType.text,
+                    validator: FormBuilderValidators.required(),
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                ],
                 Row(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [

--- a/frontend/lib/src/controllers/account_details_controller.dart
+++ b/frontend/lib/src/controllers/account_details_controller.dart
@@ -15,6 +15,7 @@ class AccountDetailsController extends GetxController {
   ).obs;
 
   Account get account => _account.value;
+  set setAccount(Account newValue) => _account.value = newValue;
 
   Future<Account?> getUserAccount({String accountId = ''}) async {
     final result = await AccountService.getUserAccount(

--- a/frontend/lib/src/features/dashboard/components/account_card.dart
+++ b/frontend/lib/src/features/dashboard/components/account_card.dart
@@ -22,7 +22,7 @@ class AccountCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final AccountDetailsController accountDetailsController =
+    final AccountDetailsController controller =
         Get.put(AccountDetailsController());
 
     return Padding(
@@ -104,7 +104,7 @@ class AccountCard extends StatelessWidget {
                         text: 'Transfer',
                         backgroundColor: const Color(0xFFC106C5),
                         onClick: () {
-                          accountDetailsController.setAccount = account;
+                          controller.setAccount = account;
                           Get.bottomSheet(
                             TransactionComponent(
                               label: 'Transfer Cash',

--- a/frontend/lib/src/features/dashboard/components/account_card.dart
+++ b/frontend/lib/src/features/dashboard/components/account_card.dart
@@ -7,6 +7,7 @@ import 'package:frontend/src/features/dashboard/components/account_card_button.d
 import 'package:frontend/src/models/account.dart';
 import 'package:frontend/src/navigators/dashboard_screen_navigator.dart';
 import 'package:frontend/src/enums/transaction_enum.dart';
+import 'package:frontend/src/controllers/account_details_controller.dart';
 
 /*
   Card widget used in dashboard.dart
@@ -21,6 +22,9 @@ class AccountCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final AccountDetailsController accountDetailsController =
+        Get.put(AccountDetailsController());
+
     return Padding(
       padding: const EdgeInsets.only(bottom: 10.0),
       child: Card(
@@ -100,6 +104,7 @@ class AccountCard extends StatelessWidget {
                         text: 'Transfer',
                         backgroundColor: const Color(0xFFC106C5),
                         onClick: () {
+                          accountDetailsController.setAccount = account;
                           Get.bottomSheet(
                             TransactionComponent(
                               label: 'Transfer Cash',


### PR DESCRIPTION
### Issue Links
- [backlog](https://framgiaph.backlog.com/view/SIM_FLUTTER-117)
- [slack](https://sun-philippine.slack.com/archives/C059L7XAXFB/p1689307206452519)

###  Notes
- This issue occurs when the user has a long middle name and only inputs the middle initial. As a result, the transfer transaction will not proceed.
- Therefore we will change the label so that user can Identify that he/she need to input the recipient's complete name.

TO INCLUDE:
- Transfer
  - Change Description to Purpose
- Deposit
  - Remove Description field

### Definition of done
- [x] Should still be able to transfer
- [x] Display Recipient's Complete Name as the label
- [x] Transfer
  - Change Description to Purpose
  - Transferring to same account is not valid
- [x] Deposit
  - Remove Description field
   
### Screenshots


https://github.com/framgia/sph-flutter/assets/97145763/ad8e12ec-3494-482f-8d3e-865929ffc379



