### PR TITLE
[SIM_FLUTTER-112] [Improvement] Add "Account Number" in Dashboard and Account Details page

### DIFF
--- a/frontend/lib/src/features/account_details/account_details_page.dart
+++ b/frontend/lib/src/features/account_details/account_details_page.dart
@@ -59,30 +59,66 @@ class AccountDetailsPage extends StatelessWidget {
                       padding: const EdgeInsets.symmetric(
                         vertical: 21,
                       ),
-                      child: Center(
                         child: Column(
                           children: [
-                            const Text(
-                              "Balance",
-                              style: TextStyle(
-                                color: Color(0xFF6D7881),
-                                fontSize: 14,
-                                fontWeight: FontWeight.w700,
+                            SizedBox(
+                              height: 21,
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Obx(
+                                    () => Text(
+                                      controller.account.accountName,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .labelMedium!
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                    ),
+                                  ),
+                                  const VerticalDivider(
+                                    color: Color(0xFF6D7881),
+                                    width: 20,
+                                    thickness: 1,
+                                    indent: 0,
+                                    endIndent: 0,
+                                  ),
+                                  Obx(
+                                    () => Text(
+                                      controller.account.accountNumber ?? '',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .labelSmall,
+                                    ),
+                                  ),
+                                ],
                               ),
                             ),
-                            Obx(
-                              () => Text(
-                                "PHP ${currencyFormat.format(controller.account.balance)}",
-                                style: const TextStyle(
-                                  color: Color(0xFF6D7881),
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w700,
+                            const SizedBox(height: 14,),
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                Text(
+                                  "Balance",
+                                  style: Theme.of(context).textTheme.titleSmall,
                                 ),
-                              ),
+                                const SizedBox(
+                                  width: 8,
+                                ),
+                                Obx(
+                                  () => Text(
+                                    "PHP ${currencyFormat.format(controller.account.balance)}",
+                                    style:
+                                        Theme.of(context).textTheme.labelSmall,
+                                  ),
+                                ),
+                              ],
                             ),
                           ],
                         ),
-                      ),
                     ),
                   ),
                 ),

--- a/frontend/lib/src/features/dashboard/components/account_card.dart
+++ b/frontend/lib/src/features/dashboard/components/account_card.dart
@@ -45,20 +45,52 @@ class AccountCard extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  account.accountName,
-                  style: Theme.of(context).textTheme.labelMedium!.copyWith(
-                        fontWeight: FontWeight.bold,
-                      ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 5.0),
-                  child: Text(
-                    "Balance: ${currencyFormat.format(account.balance)} Php",
-                    style: Theme.of(context).textTheme.labelSmall!.copyWith(
-                          fontWeight: FontWeight.normal,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          account.accountName,
+                          style:
+                              Theme.of(context).textTheme.labelMedium!.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                  ),
                         ),
-                  ),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 5.0),
+                          child: Text(
+                            "Account Number: ${account.accountNumber?.substring(7)}",
+                            style: Theme.of(context).textTheme.labelSmall,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Column(
+                      children: [
+                        Text(
+                          "Balance",
+                          style:
+                              Theme.of(context).textTheme.labelMedium!.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(top: 5.0),
+                          child: Text(
+                            "${currencyFormat.format(account.balance)} Php",
+                            style: Theme.of(context)
+                                .textTheme
+                                .labelSmall!
+                                .copyWith(
+                                  fontWeight: FontWeight.normal,
+                                ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
                 Padding(
                   padding: const EdgeInsets.only(top: 15.0),


### PR DESCRIPTION
### Issue links
- [backlog](https://framgiaph.backlog.com/view/SIM_FLUTTER-112)
- [slack](https://sun-philippine.slack.com/archives/C059L7XAXFB/p1689326900886749)

### Definition of done
- [x] dashboard
  - [x] display last 4 digit account number
- [x] details
  - [x] display full account number

### Notes
- na

### Recording
-1 

![image](https://github.com/framgia/sph-flutter/assets/95029803/c83e8041-625b-4c51-96d0-7f11dfc5328a)


-2 

![image](https://github.com/framgia/sph-flutter/assets/95029803/90a77fe7-f427-4b52-80b7-c9577e66650e)
