### PR TITLE
[SIM_FLUTTER-119][Bug] Display the Middle Initial in the User List

### DIFF
--- a/frontend/lib/src/features/admin_user_list/components/user_list_tile.dart
+++ b/frontend/lib/src/features/admin_user_list/components/user_list_tile.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 import 'package:frontend/src/features/admin_user_list/components/user_delete_dialog.dart';
+import 'package:frontend/src/helper/user_full_name.dart';
 import 'package:frontend/src/models/user.dart';
 import 'package:frontend/src/navigators/users_list_screen_navigator.dart';
 
@@ -33,7 +34,7 @@ class UserListTile extends StatelessWidget {
         height: 50,
         alignment: Alignment.centerLeft,
         child: Text(
-          '${user.firstName} ${user.lastName}',
+          userFullName(user),
           style: Theme.of(context)
               .textTheme
               .labelLarge!

--- a/frontend/lib/src/helper/user_full_name.dart
+++ b/frontend/lib/src/helper/user_full_name.dart
@@ -1,10 +1,14 @@
 import 'package:frontend/src/models/user.dart';
 
+import 'capitalize_first_letter.dart';
+
 // constructs a full Name from a user object
 // ex. Foo X. Bar
 // or  Bar Foo
 String userFullName(User user) {
-  final middleName = user.middleName != null ? '${user.middleName[0]}. ' : '';
+  final middleName = capitalizeFirstLetter(
+    user.middleName != null ? '${user.middleName[0]}. ' : '',
+  );
 
-  return '${user.firstName} $middleName${user.lastName}';
+  return '${capitalizeFirstLetter(user.firstName)} $middleName${capitalizeFirstLetter(user.lastName)}';
 }


### PR DESCRIPTION
### Links
[SIM_FLUTTER-68](https://framgiaph.backlog.com/view/SIM_FLUTTER-119)
[Slack](https://sun-philippine.slack.com/archives/C059L7XAXFB/p1689736292347129)

### Definition of done
- [x] Display the Middle Initial in the User List

### Notes
None

### Test Viewpoints:
- Display Middle Initial
- Display dynamic names
- Can still delete user accounts
- Can filter user accounts via first name, middle name, and last name

### Recordings

![image](https://github.com/framgia/sph-flutter/assets/97145763/e5f45d84-e0bd-422e-9441-8659ecc16393)




