### PR TITLE
[SIM_FLUTTER-121] [REFACTOR] Change classname of ScreenArguments for Account pages

### DIFF
--- a/frontend/lib/src/features/account_details/account_details_page.dart
+++ b/frontend/lib/src/features/account_details/account_details_page.dart
@@ -26,7 +26,7 @@ class AccountDetailsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final arguments =
-        ModalRoute.of(context)!.settings.arguments as ScreenArguments;
+        ModalRoute.of(context)!.settings.arguments as AccountScreenArguments;
     AccountDetailsController controller = Get.put(AccountDetailsController());
     SpendingBreakdownController spendingBreakdownController =
         Get.put(SpendingBreakdownController());
@@ -217,7 +217,8 @@ class AccountDetailsPage extends StatelessWidget {
                           onPressed: () {
                             dashboardAppNav.currentState?.pushNamed(
                               '/transactionHistory',
-                              arguments: ScreenArguments(arguments.accountId),
+                              arguments:
+                                  AccountScreenArguments(arguments.accountId),
                             );
                           },
                         ),
@@ -232,7 +233,7 @@ class AccountDetailsPage extends StatelessWidget {
                   onTap: () {
                     dashboardAppNav.currentState?.pushNamed(
                       '/spendingBreakdown',
-                      arguments: ScreenArguments(arguments.accountId),
+                      arguments: AccountScreenArguments(arguments.accountId),
                     );
                   },
                 ),

--- a/frontend/lib/src/features/dashboard/components/account_card.dart
+++ b/frontend/lib/src/features/dashboard/components/account_card.dart
@@ -35,7 +35,7 @@ class AccountCard extends StatelessWidget {
           onTap: () {
             dashboardAppNav.currentState?.pushNamed(
               '/accountDetails',
-              arguments: ScreenArguments(account.id!),
+              arguments: AccountScreenArguments(account.id!),
             );
           },
           child: Padding(
@@ -161,8 +161,8 @@ class AccountCard extends StatelessWidget {
   }
 }
 
-class ScreenArguments {
+class AccountScreenArguments {
   final String accountId;
 
-  ScreenArguments(this.accountId);
+  AccountScreenArguments(this.accountId);
 }

--- a/frontend/lib/src/features/spending_breakdown/spending_breakdown_page.dart
+++ b/frontend/lib/src/features/spending_breakdown/spending_breakdown_page.dart
@@ -25,7 +25,7 @@ class SpendingBreakdownPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final arguments =
-        ModalRoute.of(context)!.settings.arguments as ScreenArguments;
+        ModalRoute.of(context)!.settings.arguments as AccountScreenArguments;
     SpendingBreakdownController controller =
         Get.put(SpendingBreakdownController());
 
@@ -41,7 +41,7 @@ class SpendingBreakdownPage extends StatelessWidget {
               // show the floating button again
               dashboardAppNav.currentState?.pushNamed(
                 '/accountDetails',
-                arguments: ScreenArguments(arguments.accountId),
+                arguments: AccountScreenArguments(arguments.accountId),
               );
             },
           ),

--- a/frontend/lib/src/features/transaction_history/transaction_history.dart
+++ b/frontend/lib/src/features/transaction_history/transaction_history.dart
@@ -23,7 +23,7 @@ class TransactionHistory extends StatelessWidget {
     TransactionController controller = Get.put(TransactionController());
 
     final arguments =
-        ModalRoute.of(context)!.settings.arguments as ScreenArguments;
+        ModalRoute.of(context)!.settings.arguments as AccountScreenArguments;
 
     controller.resetFilters(arguments.accountId);
 
@@ -41,7 +41,7 @@ class TransactionHistory extends StatelessWidget {
               onTap: () {
                 dashboardAppNav.currentState?.pushNamed(
                   '/accountDetails',
-                  arguments: ScreenArguments(arguments.accountId),
+                  arguments: AccountScreenArguments(arguments.accountId),
                 );
               },
             ),


### PR DESCRIPTION
### Links
[Backlog](https://framgiaph.backlog.com/view/SIM_FLUTTER-121)
[Slack](https://sun-philippine.slack.com/archives/C059L7XAXFB/p1689831261401219)

### Definition of done
- Refactor ScreenArguments 

### Notes
Pages affected:
- Account details page
- Transaction history page
- Transaction breakdown page